### PR TITLE
fix English grammar of `each`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ property based testing library for Scala
 
 ### features
 - real `scala.FunctionN` generators using [`Cogen`](core/src/main/scala/scalaprops/Cogen.scala) (aka [CoArbitrary](https://hackage.haskell.org/package/QuickCheck-2.8.1/docs/Test-QuickCheck-Arbitrary.html#t:CoArbitrary) in QuickCheck). scalaprops can generate not only constant Functions
-- flexible parameter settings for each tests
+- flexible parameter settings for each test
 - timeout
 - flexible law checking like [discipline](https://github.com/typelevel/discipline)
  - discipline uses only `String` for test id. but scalaprops can use other than `String`


### PR DESCRIPTION
`each` is followed by a singular form of a noun such as `test`.