### PR TITLE
Add ranged floating-number Gen

### DIFF
--- a/gen/src/main/scala/scalaprops/Gen.scala
+++ b/gen/src/main/scala/scalaprops/Gen.scala
@@ -377,11 +377,7 @@ object Gen extends GenInstances0 {
     chooseIntBitsToFloat(0, 0x7f7fffff)
 
   val genFiniteFloat: Gen[Float] =
-    genIntAll.map { n =>
-      import java.lang.Float.{ intBitsToFloat, isNaN, isInfinite }
-      val x = intBitsToFloat(n)
-      if (isNaN(x) || isInfinite(x)) 0F else x
-    }
+    Gen.oneOf(negativeFiniteFloat, nonNegativeFiniteFloat)
 
   def chooseLongBitsToDouble(from: Long, to: Long): Gen[Double] =
     Choose[Long].withBoundaries(from, to).map(java.lang.Double.longBitsToDouble)
@@ -405,11 +401,7 @@ object Gen extends GenInstances0 {
     chooseLongBitsToDouble(0L, 0x7fefffffffffffffL)
 
   val genFiniteDouble: Gen[Double] =
-    genLongAll.map { n =>
-      import java.lang.Double.{ longBitsToDouble, isNaN, isInfinite }
-      val x = longBitsToDouble(n)
-      if (isNaN(x) || isInfinite(x)) 0D else x
-    }
+    Gen.oneOf(negativeFiniteDouble, nonNegativeFiniteDouble)
 
   val genSmallBigInt: Gen[BigInt] =
     genLongAll.map(BigInt(_))

--- a/gen/src/main/scala/scalaprops/Gen.scala
+++ b/gen/src/main/scala/scalaprops/Gen.scala
@@ -355,12 +355,54 @@ object Gen extends GenInstances0 {
     gen((_, r) => r.nextLong)
 
 
+  def chooseIntBitsToFloat(from: Int, to: Int): Gen[Float] =
+    Choose[Int].withBoundaries(from, to).map(java.lang.Float.intBitsToFloat)
+
+  val negativeFloat: Gen[Float] =
+    chooseIntBitsToFloat(0x80000000, 0xff800000)
+
+  val positiveFloat: Gen[Float] =
+    chooseIntBitsToFloat(1, 0x7f800000)
+
+  val nonNegativeFloat: Gen[Float] =
+    chooseIntBitsToFloat(0, 0x7f800000)
+
+  val negativeFiniteFloat: Gen[Float] =
+    chooseIntBitsToFloat(0x80000000, 0xff7fffff)
+
+  val positiveFiniteFloat: Gen[Float] =
+    chooseIntBitsToFloat(1, 0x7f7fffff)
+
+  val nonNegativeFiniteFloat: Gen[Float] =
+    chooseIntBitsToFloat(0, 0x7f7fffff)
+
   val genFiniteFloat: Gen[Float] =
     genIntAll.map { n =>
       import java.lang.Float.{ intBitsToFloat, isNaN, isInfinite }
       val x = intBitsToFloat(n)
       if (isNaN(x) || isInfinite(x)) 0F else x
     }
+
+  def chooseLongBitsToDouble(from: Long, to: Long): Gen[Double] =
+    Choose[Long].withBoundaries(from, to).map(java.lang.Double.longBitsToDouble)
+
+  val negativeDouble: Gen[Double] =
+    chooseLongBitsToDouble(0x8000000000000000L, 0xfff0000000000000L)
+
+  val positiveDouble: Gen[Double] =
+    chooseLongBitsToDouble(1L, 0x7ff0000000000000L)
+
+  val nonNegativeDouble: Gen[Double] =
+    chooseLongBitsToDouble(0L, 0x7ff0000000000000L)
+
+  val negativeFiniteDouble: Gen[Double] =
+    chooseLongBitsToDouble(0x8000000000000000L, 0xffefffffffffffffL)
+
+  val positiveFiniteDouble: Gen[Double] =
+    chooseLongBitsToDouble(1L, 0x7fefffffffffffffL)
+
+  val nonNegativeFiniteDouble: Gen[Double] =
+    chooseLongBitsToDouble(0L, 0x7fefffffffffffffL)
 
   val genFiniteDouble: Gen[Double] =
     genLongAll.map { n =>

--- a/scalaprops/src/test/scala/scalaprops/GenTest.scala
+++ b/scalaprops/src/test/scala/scalaprops/GenTest.scala
@@ -121,16 +121,31 @@ object GenTest extends Scalaprops {
   val posInt = Property.forAllG(Gen.positiveInt){_ > 0}
   val posShort = Property.forAllG(Gen.positiveShort){_ > 0}
   val posByte = Property.forAllG(Gen.positiveByte){_ > 0}
+  val posFloat = Property.forAllG(Gen.positiveFloat){_ > 0.0f}
+  val posDouble = Property.forAllG(Gen.positiveDouble){_ > 0.0d}
+  val posFiniteFloat = Property.forAllG(Gen.positiveFiniteFloat){f => f > 0.0f && !f.isInfinity}
+  val posFiniteDouble = Property.forAllG(Gen.positiveFiniteDouble){d => d > 0.0d && !d.isInfinity}
 
   val negLong = Property.forAllG(Gen.negativeLong){_ < 0}
   val negInt = Property.forAllG(Gen.negativeInt){_ < 0}
   val negShort = Property.forAllG(Gen.negativeShort){_ < 0}
   val negByte = Property.forAllG(Gen.negativeByte){_ < 0}
+  val negFloat = Property.forAllG(Gen.negativeFloat){_.compare(0.0f) < 0}
+  val negDouble = Property.forAllG(Gen.negativeDouble){_.compare(0.0d) < 0}
+  val negFiniteFloat = Property.forAllG(Gen.negativeFiniteFloat){f => f.compare(0.0f) < 0 && !f.isInfinity}
+  val negFiniteDouble = Property.forAllG(Gen.negativeFiniteDouble){d => d.compare(0.0d) < 0 && !d.isInfinity}
 
   val nonNegLong = Property.forAllG(Gen.nonNegativeLong){0 <= _}
   val nonNegInt = Property.forAllG(Gen.nonNegativeInt){0 <= _}
   val nonNegShort = Property.forAllG(Gen.nonNegativeShort){0 <= _}
   val nonNegByte = Property.forAllG(Gen.nonNegativeByte){0 <= _}
+  val nonNegFloat = Property.forAllG(Gen.nonNegativeFloat){f => f.compare(0.0f) >= 0 && !f.isNaN}
+  val nonNegDouble = Property.forAllG(Gen.nonNegativeDouble){f => f.compare(0.0d) >= 0 && !f.isNaN}
+  val nonNegFiniteFloat = Property.forAllG(Gen.nonNegativeFiniteFloat){f => f.compare(0.0f) >= 0 && !f.isInfinity && !f.isNaN}
+  val nonNegFiniteDouble = Property.forAllG(Gen.nonNegativeFiniteDouble){d => d.compare(0.0d) >= 0 && !d.isInfinity && !d.isNaN}
+
+  val finiteFloat = Property.forAllG(Gen.genFiniteFloat){f => !f.isInfinity && !f.isNaN}
+  val finiteDouble = Property.forAllG(Gen.genFiniteDouble){d => !d.isInfinity && !d.isNaN}
 
   val genFunction = {
     def test1[A: Gen: Cogen](name: String) =


### PR DESCRIPTION
Add `Gen` instances for `Float` and `Double`:


|Instance|Including|Excluding|
|:------:|---------|---------|
|`negativeFloat` <br/> `negativeDouble`|negative numbers <br/> `-0.0` <br/> `-Infinity`|positive numbers <br/> `0.0` <br/> `Infinity` <br/> `NaN`|
|`positiveFloat` <br/> `positiveDouble`|positive numbers <br/> `Infinity`|negative numbers <br/> `0.0` <br/> `-0.0` <br/> `-Infinity` <br/> `NaN`|
|`nonNegativeFloat` <br/> `nonNegativeDouble`|positive numbers <br/> `0.0` <br/> `Infinity`|negative numbers <br/> `-0.0` <br/> `-Infinity` <br/> `NaN`|
|`negativeFiniteFloat` <br/> `negativeFiniteDouble`|negative numbers <br/> `-0.0`|positive numbers <br/> `0.0` <br/> `Infinity` <br/> `-Infinity` <br/> `NaN`|
|`positiveFiniteFloat` <br/> `positiveFiniteDouble`|positive numbers|negative numbers <br/> `0.0` <br/> `-0.0` <br/> `Infinity` <br/> `-Infinity` <br/> `NaN`|
|`nonNegativeFiniteFloat` <br/> `nonNegativeFiniteDouble`|positive numbers <br/> `0.0`|negative numbers <br/> `-0.0` <br/> `Infinity` <br/> `-Infinity` <br/> `NaN`|

And rewrite `genFiniteFloat` and `genFiniteDouble` using negative and non-negative finite gen.
