### PR TITLE
Suffix test runtime with 'ms'

### DIFF
--- a/scalaprops/src/main/scala/scalaprops/ScalapropsListener.scala
+++ b/scalaprops/src/main/scala/scalaprops/ScalapropsListener.scala
@@ -46,11 +46,11 @@ object ScalapropsListener {
     private[this] def event2string(event: ScalapropsEvent) =
       event.result match {
         case \&/.That(r) =>
-          r.toString + " " + event.duration
+          r.toString + " " + event.duration + "ms"
         case \&/.Both(_, r) =>
-          r.toString + " " + event.duration
+          r.toString + " " + event.duration + "ms"
         case \&/.This(e) =>
-          e.toString + " " + event.duration
+          e.toString + " " + event.duration + "ms"
       }
 
     override def onFinishAll(obj: Scalaprops, result: Tree[(Any, LazyOption[(Property, Param, ScalapropsEvent)])], logger: Logger): Unit = {


### PR DESCRIPTION
This is a tiny change to enhance usability.
I was momentarily confused as to what the number after the `Passed` object meant, had to look it up in the code.
Adding the "ms" suffix should make its meaning obvious.

Output before:

```
`- contravariant 
        `- contravariant 
          +- identity .................................................. Passed(100,0,LongSeed(162506766292214)) 3
          `- composite .................................................. Passed(100,0,LongSeed(162506769458167)) 9
```

Output after:

```
`- contravariant 
        `- contravariant 
          +- identity .................................................. Passed(100,0,LongSeed(162506766292214)) 3ms
          `- composite .................................................. Passed(100,0,LongSeed(162506769458167)) 9ms
```